### PR TITLE
TeamsGroupPolicyAssignment: Skip assignments that have orphaned/deleted groups or without display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsGroupPolicyAssignment
+  * Skip assignments that have orphaned/deleted groups or without display name
+    instead of throwing an error
+    FIXES [#4407](https://github.com/microsoft/Microsoft365DSC/issues/4407)
 
 # 1.24.228.1
 


### PR DESCRIPTION
#### Pull Request (PR) description

If an assignment has a group that has been deleted, and/or orphaned, then skip it instead of throwing an error otherwise all assignments won't be saved into the blueprint even for the ones that were successfully exported up until the error occurred.

#### This Pull Request (PR) fixes the following issues

- Fixes #4407